### PR TITLE
Add /bk unblock feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It supports two commands:
 
 ## Usage
 
-Create a [Buildkite API Access Token](https://buildkite.com/docs/apis/rest-api#authentication) with `write_builds` scope, and save it to your GitHub repository’s **Settings → Secrets** as `BUILDKITE_API_TOKEN`. Then you can configure your Actions workflow with your Buildkite `org-slug` and `pipeline-slug`.
+Create a [Buildkite API Access Token](https://buildkite.com/docs/apis/rest-api#authentication) with `read_builds` & `write_builds` scope, and save it to your GitHub repository’s **Settings → Secrets** as `BUILDKITE_API_TOKEN`. Then you can configure your Actions workflow with your Buildkite `org-slug` and `pipeline-slug`.
 
 Update your [Pipeline YAML Steps](https://buildkite.com/docs/tutorials/pipeline-upgrade#using-yaml-steps-for-new-pipelines) to include the following in the UI steps editor:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ A [GitHub Action](https://github.com/actions) for triggering a build on a [Build
 This action uses the [Buildkite Trigger Pipeline Action](https://github.com/buildkite/trigger-pipeline-action/) as a base to send the builds to Buildkite.
 
 ## Features
-It supports two commands:
+It supports three commands:
 - `/bk trigger <pipeline-slug>`
 - `/bk pipeline <file.yml>`
+- `/bk unblock`
 
 ## Usage
 
@@ -29,6 +30,7 @@ Create a [Pull Request](https://docs.github.com/en/pull-requests/collaborating-w
 
 - `/bk trigger <pipeline-slug>` will trigger a build the PR with it's details on a **new** pipeline based on whatever `pipeline-slug` is provided, and is valid in your Organization.
 - `/bk pipeline <file.yml>` will trigger a build the PR with it's details on the **existing** pipeline (via the `buildkite_pipeline` input parameter in the workflow)  with a **new** yaml file specified in the command. The yaml file must exist either in the repo, or the PR.
+- `/bk unblock` will unblock the latest build **(that has no inputs required)** associated with the PR. This will not unblock builds that require direct input currently.
 
 ## Configuration Options
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ runs:
           COMMAND_TYPE="pipeline"
           PIPELINE_FILE=$(echo "$COMMENT_BODY" | grep -oP '(?<=/bk pipeline ).+')
           echo "PIPELINE_FILE=$PIPELINE_FILE" >> $GITHUB_ENV
+        elif echo "$COMMENT_BODY" | grep -qP '^/bk unblock$'; then
+          COMMAND_TYPE="unblock"
         else
           echo "Invalid command."
           exit 1
@@ -98,3 +100,35 @@ runs:
           }
         ignore_pipeline_branch_filter: true
         send_pull_request: true
+
+    - name: Fetch Latest Build ID and Job ID
+      if: env.COMMAND_TYPE == 'unblock'
+      shell: bash
+      run: |
+        LATEST_BUILD=$(curl -s -H "Authorization: Bearer ${{ inputs.buildkite_api_token }}" "https://api.buildkite.com/v2/organizations/${{ inputs.buildkite_org }}/pipelines/${{ inputs.buildkite_pipeline }}/builds?branch=${{ env.PR_BRANCH }}&state=blocked")
+        echo "Latest build response: $LATEST_BUILD"
+        # Accessing the first element in the array
+        BUILD_NUMBER=$(echo "$LATEST_BUILD" | jq -r '.[0].number')
+        JOB_ID=$(echo "$LATEST_BUILD" | jq -r '.[0].jobs[] | select(.state == "blocked") | .id')
+        if [ "$BUILD_NUMBER" == "null" ] || [ "$JOB_ID" == "null" ]; then
+          echo "No running builds or blocked jobs found for pipeline ${{ inputs.buildkite_pipeline }} on branch ${{ env.PR_BRANCH }}"
+          exit 1
+        fi
+        echo "Fetched latest build number: $BUILD_NUMBER"
+        echo "Fetched blocked job ID: $JOB_ID"
+        echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
+        echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
+
+    - name: Unblock Buildkite Job
+      if: env.COMMAND_TYPE == 'unblock'
+      shell: bash
+      run: |
+        curl -X PUT "https://api.buildkite.com/v2/organizations/${{ inputs.buildkite_org }}/pipelines/${{ inputs.buildkite_pipeline }}/builds/${{ env.BUILD_NUMBER }}/jobs/${{ env.JOB_ID }}/unblock" \
+        -H "Authorization: Bearer ${{ inputs.buildkite_api_token }}" \
+        -H "Content-Type: application/json" \
+        -d '{
+          "fields": {
+            "name": "GitHub Action",
+            "email": "github@action.com"
+          }
+        }'


### PR DESCRIPTION
This PR introduces a basic /bk unblock feature. 

When you use /bk unblock, it will attempt to grab the latest build based on the PR and run the REST API /unblock from Buildkite.